### PR TITLE
Fix inequality relation comparison bug

### DIFF
--- a/src/math_verify/grader.py
+++ b/src/math_verify/grader.py
@@ -341,8 +341,11 @@ def sympy_compare_relational(
         pass
 
     # Check flipped inequalities (a <= b equals b >= a)
-    if INVERSE_RELATIONS[type(gold)] is type(pred) and are_flipped_inequalities_equal(  # type: ignore
-        gold, pred
+    inverse_type = INVERSE_RELATIONS.get(type(gold))
+    if (
+        inverse_type is not None
+        and inverse_type is type(pred)
+        and are_flipped_inequalities_equal(gold, pred)
     ):
         return True
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -925,3 +925,9 @@ def test_set_rel_assymetry(gold, pred, expected, allow_set_relation_comp):
 )
 def test_float_precision(gold, pred, expected):
     assert compare_strings(gold, pred, match_types=["latex", "expr"], precision=5) == expected
+
+
+def test_not_equal_vs_less_than():
+    gold = sympy.Ne(1, 2, evaluate=False)
+    pred = sympy.Lt(1, 2)
+    assert verify(gold, pred) is False


### PR DESCRIPTION
## Summary
- guard against unsupported relations when checking inverse inequalities
- test verifying Ne vs Lt doesn't crash or return true is merged into main test suite

## Testing
- `pytest -q`
