### PR TITLE
Skip solving tuples in relational expressions

### DIFF
--- a/src/math_verify/grader.py
+++ b/src/math_verify/grader.py
@@ -274,6 +274,19 @@ def sympy_compare_interval(
 def sympy_solve_and_compare(
     gold: Relational, pred: Relational, float_rounding: int, numeric_precision: int
 ) -> bool:
+    # SymPy's solve does not support equations where either side is a Tuple,
+    # Matrix or Set. Calling solve on such expressions leads to deprecation
+    # warnings (and potential errors) inside SymPy's solver when it tries to
+    # construct an Add expression with non-Expr arguments. We short-circuit in
+    # those cases and simply return False to avoid spamming warnings.
+    unsupported_types = (Tuple, MatrixBase, MatrixExpr, Set)
+    if any(
+        isinstance(side, unsupported_types)
+        for rel in (gold, pred)
+        for side in (rel.lhs, rel.rhs)
+    ):
+        return False
+
     solved_gold = list(ordered(solve(gold, gold.free_symbols)))
     solved_pred = list(ordered(solve(pred, pred.free_symbols)))
     # Equalities should return list of dicts of solutions

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -23,6 +23,7 @@
 import pytest
 import sympy
 import math
+import warnings
 
 from math_verify import ExprExtractionConfig, LatexExtractionConfig, parse, verify
 from math_verify.grader import sympy_expr_eq
@@ -925,3 +926,11 @@ def test_set_rel_assymetry(gold, pred, expected, allow_set_relation_comp):
 )
 def test_float_precision(gold, pred, expected):
     assert compare_strings(gold, pred, match_types=["latex", "expr"], precision=5) == expected
+
+
+def test_tuple_equation_no_warning():
+    """Ensure verifying tuple equations does not emit SymPy warnings"""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("error")
+        assert verify(parse("$(p,q)=(3,2)$"), parse("$(p,q)=(3,2)$"))
+        assert len(w) == 0


### PR DESCRIPTION
## Summary
- avoid calling `sympy.solve` on relations whose sides include tuples, matrices or sets to prevent warnings
- add regression test covering tuple equality
- move the tuple warning test to the main suite

## Testing
- `pytest -q`