### PR TITLE
Fix solution comparison when SymPy returns dicts

### DIFF
--- a/src/math_verify/grader.py
+++ b/src/math_verify/grader.py
@@ -198,11 +198,13 @@ def unwrap_eq(s):
         return take_last_relation(s).rhs
     return s
 
+
 def sort_key(x):
     try:
         return default_sort_key(unwrap_eq(x).evalf())
     except Exception:
         return default_sort_key(unwrap_eq(x))
+
 
 def sympy_deep_compare_set_and_tuple(
     gold: SympyFiniteSet | Tuple,
@@ -274,19 +276,32 @@ def sympy_compare_interval(
 def sympy_solve_and_compare(
     gold: Relational, pred: Relational, float_rounding: int, numeric_precision: int
 ) -> bool:
-    solved_gold = list(ordered(solve(gold, gold.free_symbols)))
-    solved_pred = list(ordered(solve(pred, pred.free_symbols)))
+    solved_gold = list(solve(gold, gold.free_symbols, dict=True))
+    solved_pred = list(solve(pred, pred.free_symbols, dict=True))
+
+    def _sort_solution(sol: dict) -> tuple:
+        return tuple(
+            sorted(
+                (k.sort_key(), v.sort_key() if hasattr(v, "sort_key") else v)
+                for k, v in sol.items()
+            )
+        )
+
     # Equalities should return list of dicts of solutions
     if isinstance(gold, Eq) and isinstance(pred, Eq):
+        sorted_gold = sorted(solved_gold, key=_sort_solution)
+        sorted_pred = sorted(solved_pred, key=_sort_solution)
         return all(
             all(
                 g_k == p_k
                 and sympy_expr_eq(g_v, p_v, float_rounding, numeric_precision)
                 for (g_k, g_v), (p_k, p_v) in zip(
-                    sorted(g.items()), sorted(p.items()), strict=True
+                    sorted(g.items(), key=lambda kv: kv[0].sort_key()),
+                    sorted(p.items(), key=lambda kv: kv[0].sort_key()),
+                    strict=True,
                 )
             )
-            for g, p in zip(ordered(solved_gold, keys=sort_key, default=False), ordered(solved_pred, keys=sort_key, default=False), strict=True)
+            for g, p in zip(sorted_gold, sorted_pred, strict=True)
         )
     else:
         return sympy_expr_eq(
@@ -623,9 +638,7 @@ def sympy_expr_eq(
             gold_variables = gold.free_symbols
             pred_variables = pred.free_symbols
             if len(gold_variables) == len(pred_variables):
-                pred = pred.subs(
-                    list(zip(pred_variables, gold_variables, strict=True))
-                )
+                pred = pred.subs(list(zip(pred_variables, gold_variables, strict=True)))
         except Exception:
             pass
 
@@ -816,7 +829,12 @@ def verify(
             target, (Basic, MatrixBase)
         ):
             return sympy_expr_eq(
-                gold, target, float_rounding, numeric_precision, allow_set_relation_comp, strict
+                gold,
+                target,
+                float_rounding,
+                numeric_precision,
+                allow_set_relation_comp,
+                strict,
             )
 
         # We don't support str / sympy.Expr comparison. Imo there is no point in doing this, as chances

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -25,7 +25,7 @@ import sympy
 import math
 
 from math_verify import ExprExtractionConfig, LatexExtractionConfig, parse, verify
-from math_verify.grader import sympy_expr_eq
+from math_verify.grader import sympy_expr_eq, sympy_solve_and_compare
 
 """
 This file contains regression tests for testing evaluation of free-flow generation for math or indices.
@@ -52,7 +52,13 @@ def compare_strings(
 
     gold_parsed = parse(gold, extraction_targets)
     pred_parsed = parse(pred, extraction_targets)
-    return verify(gold_parsed, pred_parsed, float_rounding=precision, strict=strict, allow_set_relation_comp=allow_set_relation_comp)
+    return verify(
+        gold_parsed,
+        pred_parsed,
+        float_rounding=precision,
+        strict=strict,
+        allow_set_relation_comp=allow_set_relation_comp,
+    )
 
 
 @pytest.mark.parametrize(
@@ -458,7 +464,6 @@ def test_latex_notation_math(gold, pred, expected):
         ("$z = 1 + 1 = 2$", "$z = 3+3 = 2$", 1),
         ("$z = 1 + 1 = 2$", "$z = 3+3 = 2$", 1),
         ("$2x+4y-3=0$", "$y=-\\frac{1}{2}x+\\frac{3}{4}$", 1),
-
         # Equation normalization
         ("$x^2/4 + y^2/3 = 1$", "$x^2/16 + y^2/12 = 1/4$", 1),
     ],
@@ -882,35 +887,23 @@ def test_math_extraction_additional_cases(gold, pred, expected):
     "gold, pred, expected, allow_set_relation_comp",
     [
         # No matter the arg, it should always try to compare as set if it's in the pred
-        (
-            r"$-2 \\le x \\le 7$",
-            r"$x \in [-2,7]$",
-            1,
-            True
-        ),
-        (
-            r"$-2 \\le x \\le 7$",
-            r"$x \in [-2,7]$",
-            1,
-            False
-        ),
+        (r"$-2 \\le x \\le 7$", r"$x \in [-2,7]$", 1, True),
+        (r"$-2 \\le x \\le 7$", r"$x \in [-2,7]$", 1, False),
         # If it's in gold it should only work if the arg is true
-        (
-            r"$x \in [-2,7]$",
-            r"$-2 \\le x \\le 7$",
-            1,
-            True
-        ),
-        (
-            r"$x \in [-2,7]$",
-            r"$-2 \\le x \\le 7$",
-            0,
-            False
-        ),
-    ]
+        (r"$x \in [-2,7]$", r"$-2 \\le x \\le 7$", 1, True),
+        (r"$x \in [-2,7]$", r"$-2 \\le x \\le 7$", 0, False),
+    ],
 )
 def test_set_rel_assymetry(gold, pred, expected, allow_set_relation_comp):
-    assert compare_strings(gold, pred, match_types=["latex"], allow_set_relation_comp=allow_set_relation_comp) == expected
+    assert (
+        compare_strings(
+            gold,
+            pred,
+            match_types=["latex"],
+            allow_set_relation_comp=allow_set_relation_comp,
+        )
+        == expected
+    )
 
 
 @pytest.mark.parametrize(
@@ -921,7 +914,21 @@ def test_set_rel_assymetry(gold, pred, expected, allow_set_relation_comp):
             f"$\\sqrt{{17}}$",
             1,
         )
-    ]
+    ],
 )
 def test_float_precision(gold, pred, expected):
-    assert compare_strings(gold, pred, match_types=["latex", "expr"], precision=5) == expected
+    assert (
+        compare_strings(gold, pred, match_types=["latex", "expr"], precision=5)
+        == expected
+    )
+
+
+def test_sympy_solve_and_compare_dict_solutions():
+    x, y = sympy.symbols("x y")
+    expr = sympy.Eq(x * y, 0)
+    assert sympy_solve_and_compare(
+        expr,
+        expr,
+        float_rounding=6,
+        numeric_precision=15,
+    )


### PR DESCRIPTION
## Summary
- handle lists of solution dicts in `sympy_solve_and_compare`
- move regression test into the main test suite

## Testing
- `ruff check src/math_verify/grader.py`
- `black --check tests/test_all.py src/math_verify/grader.py`
- `pytest -q`