### PR TITLE
Fix solver compare sort

### DIFF
--- a/src/math_verify/grader.py
+++ b/src/math_verify/grader.py
@@ -198,11 +198,13 @@ def unwrap_eq(s):
         return take_last_relation(s).rhs
     return s
 
+
 def sort_key(x):
     try:
         return default_sort_key(unwrap_eq(x).evalf())
     except Exception:
         return default_sort_key(unwrap_eq(x))
+
 
 def sympy_deep_compare_set_and_tuple(
     gold: SympyFiniteSet | Tuple,
@@ -274,8 +276,12 @@ def sympy_compare_interval(
 def sympy_solve_and_compare(
     gold: Relational, pred: Relational, float_rounding: int, numeric_precision: int
 ) -> bool:
-    solved_gold = list(ordered(solve(gold, gold.free_symbols)))
-    solved_pred = list(ordered(solve(pred, pred.free_symbols)))
+    solved_gold = list(
+        ordered(solve(gold, gold.free_symbols), keys=sort_key, default=False)
+    )
+    solved_pred = list(
+        ordered(solve(pred, pred.free_symbols), keys=sort_key, default=False)
+    )
     # Equalities should return list of dicts of solutions
     if isinstance(gold, Eq) and isinstance(pred, Eq):
         return all(
@@ -286,7 +292,11 @@ def sympy_solve_and_compare(
                     sorted(g.items()), sorted(p.items()), strict=True
                 )
             )
-            for g, p in zip(ordered(solved_gold, keys=sort_key, default=False), ordered(solved_pred, keys=sort_key, default=False), strict=True)
+            for g, p in zip(
+                ordered(solved_gold, keys=sort_key, default=False),
+                ordered(solved_pred, keys=sort_key, default=False),
+                strict=True,
+            )
         )
     else:
         return sympy_expr_eq(
@@ -623,9 +633,7 @@ def sympy_expr_eq(
             gold_variables = gold.free_symbols
             pred_variables = pred.free_symbols
             if len(gold_variables) == len(pred_variables):
-                pred = pred.subs(
-                    list(zip(pred_variables, gold_variables, strict=True))
-                )
+                pred = pred.subs(list(zip(pred_variables, gold_variables, strict=True)))
         except Exception:
             pass
 
@@ -816,7 +824,12 @@ def verify(
             target, (Basic, MatrixBase)
         ):
             return sympy_expr_eq(
-                gold, target, float_rounding, numeric_precision, allow_set_relation_comp, strict
+                gold,
+                target,
+                float_rounding,
+                numeric_precision,
+                allow_set_relation_comp,
+                strict,
             )
 
         # We don't support str / sympy.Expr comparison. Imo there is no point in doing this, as chances

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -20,12 +20,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import pytest
-import sympy
 import math
 
+import pytest
+import sympy
+
 from math_verify import ExprExtractionConfig, LatexExtractionConfig, parse, verify
-from math_verify.grader import sympy_expr_eq
+from math_verify.grader import sympy_expr_eq, sympy_solve_and_compare
 
 """
 This file contains regression tests for testing evaluation of free-flow generation for math or indices.
@@ -36,7 +37,7 @@ Most of the tests have been created based on observations from the model outputs
 def compare_strings(
     gold: str,
     pred: str,
-    match_types: list[str] = ["latex", "expr"],
+    match_types: list[str] | None = None,
     precision: int = 6,
     strict: bool = True,
     allow_set_relation_comp: bool = False,
@@ -44,6 +45,8 @@ def compare_strings(
     """Helper function to compare strings using the math extraction metrics"""
     # Convert string match_types to ExtractionTarget objects
     extraction_targets = []
+    if match_types is None:
+        match_types = ["latex", "expr"]
     for match_type in match_types:
         if match_type == "latex":
             extraction_targets.append(LatexExtractionConfig(boxed_match_priority=0))
@@ -52,7 +55,13 @@ def compare_strings(
 
     gold_parsed = parse(gold, extraction_targets)
     pred_parsed = parse(pred, extraction_targets)
-    return verify(gold_parsed, pred_parsed, float_rounding=precision, strict=strict, allow_set_relation_comp=allow_set_relation_comp)
+    return verify(
+        gold_parsed,
+        pred_parsed,
+        float_rounding=precision,
+        strict=strict,
+        allow_set_relation_comp=allow_set_relation_comp,
+    )
 
 
 @pytest.mark.parametrize(
@@ -458,7 +467,6 @@ def test_latex_notation_math(gold, pred, expected):
         ("$z = 1 + 1 = 2$", "$z = 3+3 = 2$", 1),
         ("$z = 1 + 1 = 2$", "$z = 3+3 = 2$", 1),
         ("$2x+4y-3=0$", "$y=-\\frac{1}{2}x+\\frac{3}{4}$", 1),
-
         # Equation normalization
         ("$x^2/4 + y^2/3 = 1$", "$x^2/16 + y^2/12 = 1/4$", 1),
     ],
@@ -882,35 +890,23 @@ def test_math_extraction_additional_cases(gold, pred, expected):
     "gold, pred, expected, allow_set_relation_comp",
     [
         # No matter the arg, it should always try to compare as set if it's in the pred
-        (
-            r"$-2 \\le x \\le 7$",
-            r"$x \in [-2,7]$",
-            1,
-            True
-        ),
-        (
-            r"$-2 \\le x \\le 7$",
-            r"$x \in [-2,7]$",
-            1,
-            False
-        ),
+        (r"$-2 \\le x \\le 7$", r"$x \in [-2,7]$", 1, True),
+        (r"$-2 \\le x \\le 7$", r"$x \in [-2,7]$", 1, False),
         # If it's in gold it should only work if the arg is true
-        (
-            r"$x \in [-2,7]$",
-            r"$-2 \\le x \\le 7$",
-            1,
-            True
-        ),
-        (
-            r"$x \in [-2,7]$",
-            r"$-2 \\le x \\le 7$",
-            0,
-            False
-        ),
-    ]
+        (r"$x \in [-2,7]$", r"$-2 \\le x \\le 7$", 1, True),
+        (r"$x \in [-2,7]$", r"$-2 \\le x \\le 7$", 0, False),
+    ],
 )
 def test_set_rel_assymetry(gold, pred, expected, allow_set_relation_comp):
-    assert compare_strings(gold, pred, match_types=["latex"], allow_set_relation_comp=allow_set_relation_comp) == expected
+    assert (
+        compare_strings(
+            gold,
+            pred,
+            match_types=["latex"],
+            allow_set_relation_comp=allow_set_relation_comp,
+        )
+        == expected
+    )
 
 
 @pytest.mark.parametrize(
@@ -918,10 +914,20 @@ def test_set_rel_assymetry(gold, pred, expected, allow_set_relation_comp):
     [
         (
             f"{math.sqrt(17):.15f}",
-            f"$\\sqrt{{17}}$",
+            "$\\sqrt{17}$",
             1,
         )
-    ]
+    ],
 )
 def test_float_precision(gold, pred, expected):
-    assert compare_strings(gold, pred, match_types=["latex", "expr"], precision=5) == expected
+    assert (
+        compare_strings(gold, pred, match_types=["latex", "expr"], precision=5)
+        == expected
+    )
+
+
+def test_sympy_solve_and_compare_multiple_solutions():
+    x, y = sympy.symbols("x y")
+    gold = sympy.Eq(x * y, 0)
+    pred = sympy.Eq(y * x, 0)
+    assert sympy_solve_and_compare(gold, pred, 6, 15)


### PR DESCRIPTION
## Summary
- fix sorting in `sympy_solve_and_compare` so solutions containing dicts do not raise a `TypeError`
- add regression test to `test_all.py` and drop separate test file

## Testing
- `ruff check src/math_verify/grader.py tests/test_all.py`
- `black --check src/math_verify/grader.py tests/test_all.py`
- `pytest -q tests/test_all.py`