### PR TITLE
Add fallback mode to metric and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.7.1]
+### Added
+- Added `fallback_mode` parameter to `math_metric` to control extraction fallback behavior.
+
 ## [0.7.0]
 ### Added
 - Added CITATION.cff file with library metadata

--- a/src/math_verify/grader.py
+++ b/src/math_verify/grader.py
@@ -198,11 +198,13 @@ def unwrap_eq(s):
         return take_last_relation(s).rhs
     return s
 
+
 def sort_key(x):
     try:
         return default_sort_key(unwrap_eq(x).evalf())
     except Exception:
         return default_sort_key(unwrap_eq(x))
+
 
 def sympy_deep_compare_set_and_tuple(
     gold: SympyFiniteSet | Tuple,
@@ -286,7 +288,11 @@ def sympy_solve_and_compare(
                     sorted(g.items()), sorted(p.items()), strict=True
                 )
             )
-            for g, p in zip(ordered(solved_gold, keys=sort_key, default=False), ordered(solved_pred, keys=sort_key, default=False), strict=True)
+            for g, p in zip(
+                ordered(solved_gold, keys=sort_key, default=False),
+                ordered(solved_pred, keys=sort_key, default=False),
+                strict=True,
+            )
         )
     else:
         return sympy_expr_eq(
@@ -623,9 +629,7 @@ def sympy_expr_eq(
             gold_variables = gold.free_symbols
             pred_variables = pred.free_symbols
             if len(gold_variables) == len(pred_variables):
-                pred = pred.subs(
-                    list(zip(pred_variables, gold_variables, strict=True))
-                )
+                pred = pred.subs(list(zip(pred_variables, gold_variables, strict=True)))
         except Exception:
             pass
 
@@ -816,7 +820,12 @@ def verify(
             target, (Basic, MatrixBase)
         ):
             return sympy_expr_eq(
-                gold, target, float_rounding, numeric_precision, allow_set_relation_comp, strict
+                gold,
+                target,
+                float_rounding,
+                numeric_precision,
+                allow_set_relation_comp,
+                strict,
             )
 
         # We don't support str / sympy.Expr comparison. Imo there is no point in doing this, as chances

--- a/src/math_verify/metric.py
+++ b/src/math_verify/metric.py
@@ -1,6 +1,6 @@
 ## Parser definition
 import logging
-from typing import Callable, Optional, Sequence
+from typing import Callable, Literal, Optional, Sequence
 
 from math_verify.grader import verify
 from math_verify.parser import ExprExtractionConfig, ExtractionTarget, parse
@@ -13,6 +13,7 @@ def math_metric(
     gold_extraction_target: Sequence[ExtractionTarget] = (ExprExtractionConfig(),),
     pred_extraction_target: Sequence[ExtractionTarget] = (ExprExtractionConfig(),),
     aggregation_function: Callable[[list[float]], float] = max,
+    fallback_mode: Literal["no_fallback", "first_match"] = "first_match",
     precision: int = 6,
 ) -> Callable[
     [list[str], list[str]], tuple[float, Optional[tuple[list[str], list[str]]]]
@@ -57,9 +58,13 @@ def math_metric(
         golds: list[str], predictions: list[str]
     ) -> tuple[float, Optional[tuple[list[str], list[str]]]]:
         extracted_predictions = [
-            parse(pred, pred_extraction_target) for pred in predictions
+            parse(pred, pred_extraction_target, fallback_mode=fallback_mode)
+            for pred in predictions
         ]
-        extracted_golds = [parse(gold, gold_extraction_target) for gold in golds]
+        extracted_golds = [
+            parse(gold, gold_extraction_target, fallback_mode=fallback_mode)
+            for gold in golds
+        ]
 
         # Assert on empty gold and warn on empty pred
         if any(len(g) == 0 for g in extracted_golds):

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -24,6 +24,8 @@ import pytest
 import sympy
 import math
 
+from math_verify.metric import math_metric
+
 from math_verify import ExprExtractionConfig, LatexExtractionConfig, parse, verify
 from math_verify.grader import sympy_expr_eq
 
@@ -52,7 +54,13 @@ def compare_strings(
 
     gold_parsed = parse(gold, extraction_targets)
     pred_parsed = parse(pred, extraction_targets)
-    return verify(gold_parsed, pred_parsed, float_rounding=precision, strict=strict, allow_set_relation_comp=allow_set_relation_comp)
+    return verify(
+        gold_parsed,
+        pred_parsed,
+        float_rounding=precision,
+        strict=strict,
+        allow_set_relation_comp=allow_set_relation_comp,
+    )
 
 
 @pytest.mark.parametrize(
@@ -458,7 +466,6 @@ def test_latex_notation_math(gold, pred, expected):
         ("$z = 1 + 1 = 2$", "$z = 3+3 = 2$", 1),
         ("$z = 1 + 1 = 2$", "$z = 3+3 = 2$", 1),
         ("$2x+4y-3=0$", "$y=-\\frac{1}{2}x+\\frac{3}{4}$", 1),
-
         # Equation normalization
         ("$x^2/4 + y^2/3 = 1$", "$x^2/16 + y^2/12 = 1/4$", 1),
     ],
@@ -882,35 +889,23 @@ def test_math_extraction_additional_cases(gold, pred, expected):
     "gold, pred, expected, allow_set_relation_comp",
     [
         # No matter the arg, it should always try to compare as set if it's in the pred
-        (
-            r"$-2 \\le x \\le 7$",
-            r"$x \in [-2,7]$",
-            1,
-            True
-        ),
-        (
-            r"$-2 \\le x \\le 7$",
-            r"$x \in [-2,7]$",
-            1,
-            False
-        ),
+        (r"$-2 \\le x \\le 7$", r"$x \in [-2,7]$", 1, True),
+        (r"$-2 \\le x \\le 7$", r"$x \in [-2,7]$", 1, False),
         # If it's in gold it should only work if the arg is true
-        (
-            r"$x \in [-2,7]$",
-            r"$-2 \\le x \\le 7$",
-            1,
-            True
-        ),
-        (
-            r"$x \in [-2,7]$",
-            r"$-2 \\le x \\le 7$",
-            0,
-            False
-        ),
-    ]
+        (r"$x \in [-2,7]$", r"$-2 \\le x \\le 7$", 1, True),
+        (r"$x \in [-2,7]$", r"$-2 \\le x \\le 7$", 0, False),
+    ],
 )
 def test_set_rel_assymetry(gold, pred, expected, allow_set_relation_comp):
-    assert compare_strings(gold, pred, match_types=["latex"], allow_set_relation_comp=allow_set_relation_comp) == expected
+    assert (
+        compare_strings(
+            gold,
+            pred,
+            match_types=["latex"],
+            allow_set_relation_comp=allow_set_relation_comp,
+        )
+        == expected
+    )
 
 
 @pytest.mark.parametrize(
@@ -921,7 +916,29 @@ def test_set_rel_assymetry(gold, pred, expected, allow_set_relation_comp):
             f"$\\sqrt{{17}}$",
             1,
         )
-    ]
+    ],
 )
 def test_float_precision(gold, pred, expected):
-    assert compare_strings(gold, pred, match_types=["latex", "expr"], precision=5) == expected
+    assert (
+        compare_strings(gold, pred, match_types=["latex", "expr"], precision=5)
+        == expected
+    )
+
+
+def test_math_metric_fallback_modes():
+    metric_no_fb = math_metric(
+        gold_extraction_target=(LatexExtractionConfig(),),
+        pred_extraction_target=(LatexExtractionConfig(),),
+        fallback_mode="no_fallback",
+    )
+    metric_fb = math_metric(
+        gold_extraction_target=(LatexExtractionConfig(),),
+        pred_extraction_target=(LatexExtractionConfig(),),
+        fallback_mode="first_match",
+    )
+
+    gold = ["$?$"]
+    pred = ["$?$"]
+    with pytest.raises(ValueError):
+        metric_no_fb(gold, pred)
+    assert metric_fb(gold, pred)[0] == 1.0


### PR DESCRIPTION
## Summary
- expose `fallback_mode` in `math_metric`
- respect the parameter when parsing gold/predictions
- test metric behaviour for both fallback modes

## Testing
- `make check`
- `make test`