### PR TITLE
Improve docs and CLI handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,13 +178,13 @@ Answer Extraction -> Expression Common Representation Conversion (SymPy) -> Gold
 
 ### Why is verify function not symmetric?
 
-The verify funciton, doesn't have symmetric behavior in two cases:
+The verify function doesn't have symmetric behavior in two cases:
 
 **1. Representation Asymmetry (Interval vs. Inequality):**
 - If the gold answer is an inequality (e.g., `1 < x < 2`) and the prediction is an interval (e.g., `(1,2)`), the verification will return `True`.
 - However, if the gold answer is an interval (e.g., `(1,2)`) and the prediction is the inequality (e.g., `1 < x < 2`), it will return `False`.
-- This asymmetry is designed to prevent models from simply returning the input inequality when a model is given task to solve an ineqaulity and instead of solving the inequality is just outputs the ineqaulity itself. If model can "learn" that it can just output the inequality without solving it, it will simply reward hack such samples.
-- This can be changed by passing `allow_set_relation_comp` to `verify`, which allows both directions of comparison. os comparison.
+ - This asymmetry is designed to prevent models from simply returning the input inequality when a model is given a task to solve an inequality and instead of solving the inequality just outputs the inequality itself. If a model can "learn" that it can just output the inequality without solving it, it will simply reward hack such samples.
+ - This can be changed by passing `allow_set_relation_comp` to `verify`, which allows both directions of comparison.
 
 **2. Solution Context Asymmetry (Number vs. Solution Chain):**
 - If the gold answer is a number (e.g., `101`) and the prediction is a solution chain leading to that number (e.g., `a+2z = 2z + a = 101`), the verification will return `True`.

--- a/evaluate_model_outputs.py
+++ b/evaluate_model_outputs.py
@@ -9,7 +9,12 @@ def parse_args():
     parser = argparse.ArgumentParser(description='Extract and evaluate answers using sympy')
     parser.add_argument('--input_csv', type=str, required=True, help='Path to input CSV file containing model outputs')
     parser.add_argument('--output_csv', type=str, required=True, help='Path to output CSV file for extracted answers')
-    parser.add_argument('--gold_is_latex', action='store_true', help='Use basic latex normalization', default=True)
+    parser.add_argument(
+        '--gold_is_latex',
+        action=argparse.BooleanOptionalAction,
+        help='Use basic latex normalization',
+        default=True,
+    )
     return parser.parse_args()
 
 def load_csv_data(csv_path: str) -> pd.DataFrame:

--- a/src/math_verify/parser.py
+++ b/src/math_verify/parser.py
@@ -672,8 +672,8 @@ def parse(
             - "first_match": Include the first string match even if parsing failed
         extraction_mode (Literal["first_match", "any_match"], optional): Strategy for extracting matches. Defaults to "any_match".
             - "first_match": Stop after finding the first match
-            - "any_match": Try to extract all possible matches, stops after first sucesful parsing attempt
-        parsing_timeout (int, optional): Maximum time in seconds to spend parsing each expression. Defaults to 3. Any timeout seconds > 0 or not None will result in the function to raise a ValueError if it's called in a threaded environment.
+            - "any_match": Try to extract all possible matches, stops after first successful parsing attempt
+        parsing_timeout (int, optional): Maximum time in seconds to spend parsing each expression. Defaults to 5. Any timeout seconds > 0 or not None will result in the function to raise a ValueError if it's called in a threaded environment.
 
     Returns:
         list: List of extracted predictions. Each prediction can be:

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -22,6 +22,7 @@ def test_timeout_expr(mock_parse_expr):
         fallback_mode="no_fallback",
     )
     assert x == []
+    mock_parse_expr.assert_called()
 
 
 @patch("math_verify.parser.latex2sympy")
@@ -41,6 +42,7 @@ def test_timeout_latex(mock_parse_latex):
         fallback_mode="no_fallback",
     )
     assert x == []
+    mock_parse_latex.assert_called()
 
 
 @patch("math_verify.grader.sympy_expr_eq")
@@ -54,3 +56,4 @@ def test_timeout_verify(mock_verify):
 
     gold = [parse("1+1")[0]]
     assert not verify(gold, gold, timeout_seconds=1)
+    mock_verify.assert_called()


### PR DESCRIPTION
## Summary
- fix README wording to keep the 'reward hack' explanation
- correct typo in parser docstring
- allow disabling `--gold_is_latex` via argparse
- document correct parse timeout default
- strengthen timeout tests by checking mocks

## Testing
- `python -m pytest -q`