### PR TITLE
Fix timeout decorator to work in threads

### DIFF
--- a/src/math_verify/grader.py
+++ b/src/math_verify/grader.py
@@ -770,7 +770,9 @@ def verify(
             - In strict mode: Variables matter and sets are not comparable with tuples
             - In non-strict mode: Variables are matched by position and sets can be compared with tuples
         timeout_seconds: Maximum time in seconds to spend on any single comparison operation.
-            Defaults to 5 seconds. Any timeout seconds > 0 or not None will result in the function to raise a ValueError if it's called in a threaded environment.
+            Defaults to 5 seconds. When called from a non-main thread the timeout is enforced
+            using a subprocess which may be slightly slower but works correctly in a
+            multi-threaded environment.
         allow_set_relation_comp: Whether to allow set - relation comparison. Defaults to False.
             - If True, set - relation comparison will be allowed in all cases.
             - If False, set - relation comparison will be allowed only if the prediction is a set.
@@ -837,14 +839,9 @@ def verify(
         try:
             return compare_single_extraction(g, t)
 
-        except ValueError as e:
-            if str(e) == "signal only works in main thread of the main interpreter":
-                raise ValueError(
-                    "Math-Verify doesn't support threaded environment due to usage of signal.alarm() in timeout mechanism. If you need to run in multithreaded environment it's recommended to set the parsing_timeout=None, which will run without timeout (and signal handling). In this case you need to handle the timeouting yourself."
-                ) from e
-            else:
-                logger.exception("Error during comparison")
-                return False
+        except ValueError:
+            logger.exception("Error during comparison")
+            return False
         except Exception:
             #! Do not attempt to print out the g and t during handling of exception
             # Because a) it can throw an exception itself and b) it can cause it to be stuck forever during str conversion

--- a/src/math_verify/parser.py
+++ b/src/math_verify/parser.py
@@ -673,7 +673,9 @@ def parse(
         extraction_mode (Literal["first_match", "any_match"], optional): Strategy for extracting matches. Defaults to "any_match".
             - "first_match": Stop after finding the first match
             - "any_match": Try to extract all possible matches, stops after first sucesful parsing attempt
-        parsing_timeout (int, optional): Maximum time in seconds to spend parsing each expression. Defaults to 3. Any timeout seconds > 0 or not None will result in the function to raise a ValueError if it's called in a threaded environment.
+        parsing_timeout (int, optional): Maximum time in seconds to spend parsing each expression. Defaults to 3.
+            In non-main threads the timeout is enforced using a subprocess which introduces
+            a small overhead but allows safe execution in multi-threaded environments.
 
     Returns:
         list: List of extracted predictions. Each prediction can be:
@@ -705,17 +707,9 @@ def parse(
             fallback_mode=fallback_mode,
             extraction_mode=extraction_mode,
         )
-    except ValueError as e:
-        # Check if it's the signal error
-        if str(e) == "signal only works in main thread of the main interpreter":
-            raise ValueError(
-                "Math-Verify 'parse' function doesn't support threaded environment due to usage of signal.alarm() in timeout mechanism. If you need to run in multithreaded environment it's recommended to set the parsing_timeout=None, which will run without timeout (and signal handling). In this case you need to handle the timeouting yourself."
-            ) from e
-        logger.exception(f"Error parsing: {pred}")
+    except TimeoutException:
+        logger.error(f"Timeout during parsing: {pred}")
         return []
     except Exception:
         logger.exception(f"Error parsing: {pred}")
-        return []
-    except TimeoutException:
-        logger.error(f"Timeout during parsing: {pred}")
         return []

--- a/src/math_verify/utils.py
+++ b/src/math_verify/utils.py
@@ -22,6 +22,7 @@
 
 import logging
 import os
+import threading
 
 from math_verify.errors import TimeoutException
 
@@ -37,8 +38,11 @@ def timeout(timeout_seconds: int | None = 10):  # noqa: C901
             Defaults to 10 seconds.
 
     Notes:
-        On Unix systems, uses a signal-based alarm approach which is more efficient as it doesn't require spawning a new process.
-        On Windows systems, uses a multiprocessing-based approach since signal.alarm is not available. This will incur a huge performance penalty.
+        On Unix systems, the main thread uses a signal-based alarm approach which is more efficient as
+        it doesn't require spawning a new process. In non-main threads or on Windows, a
+        multiprocessing-based approach is used since ``signal.alarm`` is either unavailable or
+        unsupported. This will incur a performance penalty but allows using the decorator in a
+        multi-threaded environment.
     """
     if timeout_seconds is None or timeout_seconds <= 0:
 
@@ -47,32 +51,64 @@ def timeout(timeout_seconds: int | None = 10):  # noqa: C901
 
         return no_timeout_decorator
 
+    from multiprocessing import Process, Queue
+
     if os.name == "posix":
-        # Unix-like approach: signal.alarm
+        # Unix-like approach: signal.alarm when running in main thread,
+        # otherwise fall back to multiprocessing.
         import signal
 
         def decorator(func):
             def handler(signum, frame):
                 raise TimeoutException("Operation timed out!")
 
-            def wrapper(*args, **kwargs):
+            def run_with_signal(*args, **kwargs):
                 old_handler = signal.getsignal(signal.SIGALRM)
                 signal.signal(signal.SIGALRM, handler)
                 signal.alarm(timeout_seconds)
                 try:
                     return func(*args, **kwargs)
                 finally:
-                    # Cancel the alarm and restore previous handler
                     signal.alarm(0)
                     signal.signal(signal.SIGALRM, old_handler)
+
+            def run_with_process(*args, **kwargs):
+                q = Queue()
+
+                def run_func(q, args, kwargs):
+                    try:
+                        result = func(*args, **kwargs)
+                        q.put((True, result))
+                    except Exception as e:
+                        q.put((False, e))
+
+                p = Process(target=run_func, args=(q, args, kwargs))
+                p.start()
+                p.join(timeout_seconds)
+
+                if p.is_alive():
+                    p.terminate()
+                    p.join()
+                    raise TimeoutException("Operation timed out!")
+
+                success, value = q.get()
+                if success:
+                    return value
+                else:
+                    raise value
+
+            def wrapper(*args, **kwargs):
+                if threading.current_thread() is threading.main_thread():
+                    return run_with_signal(*args, **kwargs)
+                else:
+                    return run_with_process(*args, **kwargs)
 
             return wrapper
 
         return decorator
 
     else:
-        # Windows approach: use multiprocessing
-        from multiprocessing import Process, Queue
+        # Windows approach (or other OS without signal.alarm): multiprocessing
 
         def decorator(func):
             def wrapper(*args, **kwargs):
@@ -90,17 +126,14 @@ def timeout(timeout_seconds: int | None = 10):  # noqa: C901
                 p.join(timeout_seconds)
 
                 if p.is_alive():
-                    # Timeout: Terminate the process
                     p.terminate()
                     p.join()
                     raise TimeoutException("Operation timed out!")
 
-                # If we got here, the process completed in time.
                 success, value = q.get()
                 if success:
                     return value
                 else:
-                    # The child raised an exception; re-raise it here
                     raise value
 
             return wrapper

--- a/tests/test_multithreading.py
+++ b/tests/test_multithreading.py
@@ -1,0 +1,37 @@
+import threading
+
+from math_verify.parser import parse
+from math_verify.grader import verify
+
+
+def test_parse_multithread():
+    expected = parse("1+1", fallback_mode="no_fallback")[0]
+    results = []
+
+    def worker():
+        results.append(parse("1+1", fallback_mode="no_fallback", parsing_timeout=1)[0])
+
+    threads = [threading.Thread(target=worker) for _ in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(results) == 3
+    assert all(verify(expected, r, timeout_seconds=1) for r in results)
+
+
+def test_verify_multithread():
+    gold = parse("1+1", fallback_mode="no_fallback")[0]
+    results = []
+
+    def worker():
+        results.append(verify([gold], [gold], timeout_seconds=1))
+
+    threads = [threading.Thread(target=worker) for _ in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert results == [True, True, True]

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -2,7 +2,7 @@ import time
 from unittest.mock import patch
 
 from math_verify.grader import verify
-from math_verify.parser import parse
+from math_verify.parser import parse, parse_expr_cached, parse_latex_cached
 
 
 @patch("math_verify.parser.parse_expr")
@@ -15,6 +15,7 @@ def test_timeout_expr(mock_parse_expr):
     mock_parse_expr.side_effect = delayed_parse
 
     # Test that the timeout is triggered
+    parse_expr_cached.cache_clear()
     x = parse(
         "1+1",
         parsing_timeout=1,
@@ -34,6 +35,7 @@ def test_timeout_latex(mock_parse_latex):
     mock_parse_latex.side_effect = delayed_parse
 
     # Test that the timeout is triggered
+    parse_latex_cached.cache_clear()
     x = parse(
         "$1+1$",
         parsing_timeout=1,


### PR DESCRIPTION
## Summary
- handle threaded environments in utils.timeout
- simplify parse/grader error handling and docs
- clear caches in timeout tests
- add multi-threading regression tests

## Testing
- `pytest -q`